### PR TITLE
fix(deb2itp): parse new d/copyright format for authors

### DIFF
--- a/deb2itp
+++ b/deb2itp
@@ -25,7 +25,7 @@ fi
 pkg=$(head -1 control|awk '{print $2}')
 shortdesc=$(grep ^Description: control|head -1|awk '{$1="";print}')
 ver=$(head -1 changelog|awk '{print $2}' |sed 's,(,,g;s,-.*,,g')
-auth=$(grep ^Copyright copyright | head -1|awk '{$1="";print}'|grep -v $DEBEMAIL| sed "s,2[0-9][0-9][0-9] ,,g")
+auth=$(grep ^Upstream-Contact copyright | head -1|awk '{$1="";print}')
 url=$(grep ^Homepage: control | head -1|awk '{$1="";print}')
 lic=$(grep ^License: copyright | head -1|awk '{$1="";print}')
 


### PR DESCRIPTION
The `Upstream-Contact` field of the new machine-readable d/copyright
format can be used in order to deduce author's name and contact
information.

See https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/